### PR TITLE
feat: add Archive page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -60,5 +60,29 @@
 		"fullName": "Australia-Japan Career Development Society",
 		"shortDescription": "Build a global career! Join {shortName} and connect with opportunities in Japan and Australia.",
 		"shortName": "AJC Society UNSW"
+	},
+	"Navigation": {
+		"home": "Home",
+		"archive": "Archive",
+		"newsletter": "Newsletter",
+		"articles": "Articles"
+	},
+	"ArchivePage": {
+		"title": "AJC Archive",
+		"subtitle": "A living record of AJC publications and member writing.",
+		"newsletter": "Newsletter",
+		"articles": "Articles",
+		"readOnline": "Read Online →",
+		"byline": "By {authors}",
+		"categories": {
+			"All": "All",
+			"Business": "Business",
+			"Culture": "Culture",
+			"Careers": "Careers",
+			"Events": "Events"
+		},
+		"loadMore": "Load More",
+		"noArticles": "No published articles yet.",
+		"noNewsletters": "No published newsletters yet."
 	}
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -60,5 +60,29 @@
 		"fullName": "オーストラリア・日本キャリアサークル",
 		"shortDescription": "{shortName}に参加して、日本とオーストラリアでキャリアを築く機会をつかみましょう",
 		"shortName": "AJC Society UNSW"
+	},
+	"Navigation": {
+		"home": "ホーム",
+		"archive": "アーカイブ",
+		"newsletter": "ニュースレター",
+		"articles": "記事"
+	},
+	"ArchivePage": {
+		"title": "AJC アーカイブ",
+		"subtitle": "AJCの出版物やメンバーの執筆記事の記録。",
+		"newsletter": "ニュースレター",
+		"articles": "記事",
+		"readOnline": "オンラインで読む →",
+		"byline": "著者: {authors}",
+		"categories": {
+			"All": "すべて",
+			"Business": "ビジネス",
+			"Culture": "文化",
+			"Careers": "キャリア",
+			"Events": "イベント"
+		},
+		"loadMore": "もっと読み込む",
+		"noArticles": "公開済みの記事はまだありません。",
+		"noNewsletters": "公開済みのニュースレターはまだありません。"
 	}
 }

--- a/src/app/[locale]/(home)/@modal/(.)subscribe/SubscribeModal.tsx
+++ b/src/app/[locale]/(home)/@modal/(.)subscribe/SubscribeModal.tsx
@@ -18,7 +18,7 @@ export default function SubscribeModal() {
 
 	return (
 		<dialog className="modal" onClose={onClose} open={true}>
-			<div className="modal-box rounded-lg bg-ajc-beige p-6">
+			<div className="modal-box bg-base-100 p-6">
 				<form method="dialog">
 					<button
 						className="btn btn-sm btn-circle btn-ghost absolute top-2 right-2"
@@ -30,30 +30,42 @@ export default function SubscribeModal() {
 				</form>
 				{state?.success ? (
 					<div className="flex flex-col items-center justify-center py-8">
-						<h2 className="mb-6 font-bold text-2xl">{t("completed.title")}</h2>
+						<h2 className="mb-6 text-2xl font-bold">{t("completed.title")}</h2>
 						<p className="mb-6 text-center">{t("completed.message")}</p>
 					</div>
 				) : (
 					<>
-						<h2 className="font-bold text-2xl">{t("title")}</h2>
+						<h2 className="text-2xl font-bold">{t("title")}</h2>
 						<p className="py-4">{t("description")}</p>
-						<form action={action} className="flex flex-col space-y-4">
+						<form action={action} className="space-y-4">
 							<input
-								className="input input-bordered w-full"
+								className="input input-primary w-full"
 								name="name"
 								placeholder={t("namePlaceholder")}
 								required={true}
 								type="text"
 							/>
 							<input
-								className="input input-bordered w-full"
+								className="input input-primary w-full"
 								name="email"
 								placeholder={t("emailPlaceholder")}
 								required={true}
 								type="email"
 							/>
-							<button className="btn btn-primary text-white" disabled={isPending} type="submit">
-								{isPending ? t("buttonTextPending") : t("buttonText")}
+							<button
+								aria-busy={isPending}
+								className="btn btn-primary w-full"
+								disabled={isPending}
+								type="submit"
+							>
+								{isPending ? (
+									<>
+										<span className="loading loading-spinner" />
+										{t("buttonTextPending")}
+									</>
+								) : (
+									t("buttonText")
+								)}
 							</button>
 						</form>
 					</>

--- a/src/app/[locale]/(home)/components/AboutUs.tsx
+++ b/src/app/[locale]/(home)/components/AboutUs.tsx
@@ -7,26 +7,26 @@ export default function AboutUs() {
 	const t = useTranslations("HomePage.AboutUs");
 
 	return (
-		<section>
-			<div className="flex flex-col items-center px-6 py-10 md:flex-row md:px-10">
-				<div className="mb-6 flex justify-center px-10 md:w-1/2">
+		<section className="hero bg-base-100 py-10">
+			<div className="hero-content flex-col gap-8 px-6 md:flex-row md:px-10">
+				<figure className="flex justify-center md:w-1/2">
 					<Image
 						alt="Picture of Our 2025 Team"
-						className="h-full w-full rounded-xl object-cover shadow-lg"
+						className="h-full w-full rounded-box object-cover shadow-lg"
 						src={teamPicture}
 					/>
-				</div>
+				</figure>
 
 				<div className="max-w-xl px-4 text-center md:w-1/2 md:pl-12 md:text-left">
-					<h2 className="mb-4 font-bold text-3xl capitalize">{t("title")}</h2>
-					<p className="mb-5 text-md leading-relaxed">
+					<h2 className="mb-4 text-3xl font-bold capitalize">{t("title")}</h2>
+					<p className="mb-5 leading-relaxed">
 						{t.rich("description", {
 							br: () => <br />,
 						})}
 					</p>
-					<div className="mt-4 flex">
+					<div className="mt-4 flex justify-center md:justify-start">
 						<Link
-							className="mx-auto inline-block min-w-[250px] whitespace-nowrap rounded bg-primary px-2 py-2 text-center text-white uppercase shadow hover:scale-110 hover:shadow-lg"
+							className="btn btn-primary btn-wide uppercase"
 							href="https://campus.hellorubric.com/?tab=memberships&s=12445"
 							rel="noopener noreferrer"
 							target="_blank"

--- a/src/app/[locale]/(home)/components/Featured.tsx
+++ b/src/app/[locale]/(home)/components/Featured.tsx
@@ -4,49 +4,49 @@ import { Link } from "../../../../i18n/navigation";
 import subcomRecruitment from "../images/subcom-recruitment.png";
 import welcomeEvent from "../images/welcome-event.png";
 
+const features = [
+	{
+		altKey: "subcomAlt",
+		href: "https://forms.gle/tsGYkz3nnXCzL9UcA",
+		image: subcomRecruitment,
+		titleKey: "subcomTitle",
+	},
+	{
+		altKey: "welcomeAlt",
+		href: "https://forms.gle/eP9ruxk9DGujmdWE8",
+		image: welcomeEvent,
+		titleKey: "welcomeTitle",
+	},
+] as const;
+
 export default function Featured() {
 	const t = useTranslations("HomePage.Featured");
 
 	return (
-		<section className="w-full px-4 py-8">
+		<section className="w-full bg-base-100 px-4 py-8">
 			<div className="mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl md:text-4xl">{t("title")}</h2>
-				<div className="flex w-full flex-col items-center gap-8 md:flex-row md:justify-center md:items-start">
-					<div className="flex flex-col items-center gap-4 w-full md:w-1/4 group">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
+				<div className="grid w-full max-w-4xl grid-cols-1 gap-8 md:grid-cols-2">
+					{features.map(({ altKey, href, image, titleKey }) => (
 						<Link
-							href="https://forms.gle/tsGYkz3nnXCzL9UcA"
+							className="card group bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
+							href={href}
+							key={href}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex flex-col items-center gap-4 w-full transition-transform hover:scale-105"
 						>
-							<Image
-								src={subcomRecruitment}
-								alt={t("subcomAlt")}
-								className="h-auto w-full rounded-lg shadow-lg"
-							/>
-							<span className="rounded-full bg-ajc-red px-6 py-2 text-white font-bold shadow-md transition-colors hover:bg-red-700">
-								{t("subcomTitle")}
-							</span>
+							<figure>
+								<Image
+									alt={t(altKey)}
+									className="h-auto w-full transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
+							<div className="card-body items-center p-4">
+								<span className="btn btn-primary btn-wide">{t(titleKey)}</span>
+							</div>
 						</Link>
-					</div>
-
-					<div className="flex flex-col items-center gap-4 w-full md:w-1/4 group">
-						<Link
-							href="https://forms.gle/eP9ruxk9DGujmdWE8"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="flex flex-col items-center gap-4 w-full transition-transform hover:scale-105"
-						>
-							<Image
-								src={welcomeEvent}
-								alt={t("welcomeAlt")}
-								className="h-auto w-full rounded-lg shadow-lg"
-							/>
-							<span className="rounded-full bg-ajc-red px-6 py-2 text-white font-bold shadow-md transition-colors hover:bg-red-700">
-								{t("welcomeTitle")}
-							</span>
-						</Link>
-					</div>
+					))}
 				</div>
 			</div>
 		</section>

--- a/src/app/[locale]/(home)/components/PastEvents.tsx
+++ b/src/app/[locale]/(home)/components/PastEvents.tsx
@@ -8,16 +8,19 @@ import MyNaviEvent from "../images/events/MyNavi_Event.jpg";
 const pastEvents = [
 	{
 		href: "https://docs.google.com/forms/d/e/1FAIpQLSfC_Zc8xWA-dJJYbjJJUL5sr-LtRgrAgrmsCc6A2UAVw-obng/viewform",
+		id: "hnh",
 		image: HAndHEvent,
 		translationKey: "networking",
 	},
 	{
 		href: "https://regu-20105603.hs-sites.com/kpmg-aus25",
+		id: "kpmg",
 		image: KPMGEvent,
 		translationKey: "networking",
 	},
 	{
 		href: "https://global.mynavi.jp/conts/event/aus_mcs2025jul/?utm_source=studentpartnar&utm_medium=textl&utm_campaign=2507",
+		id: "mynavi",
 		image: MyNaviEvent,
 		translationKey: "networking",
 	},
@@ -27,25 +30,25 @@ export default function PastEvents() {
 	const t = useTranslations("HomePage.PastEvents");
 
 	return (
-		<section className="w-full bg-ajc-beige-500 px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl text-ajc-text md:text-4xl">
-					{t("title")}
-				</h2>
+		<section className="w-full bg-base-200 px-4 py-8">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="flex w-full flex-wrap justify-center gap-[4vw]">
-					{pastEvents.map(({ translationKey, href, image }) => (
+					{pastEvents.map(({ id, translationKey, href, image }) => (
 						<Link
-							className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+							className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 							href={href}
-							key={translationKey}
+							key={id}
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<Image
-								alt={t(`events.${translationKey}`)}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
-								src={image}
-							/>
+							<figure>
+								<Image
+									alt={t(`events.${translationKey}`)}
+									className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
 						</Link>
 					))}
 				</div>

--- a/src/app/[locale]/(home)/components/SocialIcons.tsx
+++ b/src/app/[locale]/(home)/components/SocialIcons.tsx
@@ -7,25 +7,25 @@ const socials = [
 		hoverColour: "group-hover:fill-pink-500",
 		href: "https://www.instagram.com/ajcsocunsw/",
 		icon: FaInstagram,
-		key: "instagram",
+		label: "Instagram",
 	},
 	{
 		hoverColour: "group-hover:fill-blue-500",
 		href: "https://www.facebook.com/people/UNSW-Australia-Japan-Career-Development-Society-AJC/100095045665332/",
 		icon: FaFacebook,
-		key: "facebook",
+		label: "Facebook",
 	},
 	{
 		hoverColour: "group-hover:fill-blue-700",
 		href: "https://www.linkedin.com/company/unsw-australia-japan-career-development-society",
 		icon: FaLinkedin,
-		key: "linkedin",
+		label: "LinkedIn",
 	},
 	{
 		hoverColour: "group-hover:fill-blue-700",
 		href: "https://discord.gg/a3KJ49CwaZ",
 		icon: FaDiscord,
-		key: "discord",
+		label: "Discord",
 	},
 ] as const;
 
@@ -33,30 +33,26 @@ export default function SocialIcons() {
 	const t = useTranslations("HomePage.Social");
 
 	return (
-		<section>
-			<div className="flex items-center gap-x-[5vw]">
-				{socials.map(({ href, icon: Icon, hoverColour, key }) => (
+		<section className="flex flex-col items-center gap-5 md:gap-8">
+			<div className="flex flex-wrap items-center justify-center gap-3 md:gap-5">
+				{socials.map(({ href, icon: Icon, hoverColour, label }) => (
 					<Link
-						className="group"
+						aria-label={label}
+						className="tooltip btn btn-ghost btn-circle group h-14 w-14 min-h-14 text-base-content hover:bg-base-200"
+						data-tip={label}
 						href={href}
-						key={key}
+						key={label}
 						{...(href.startsWith("http") ? { rel: "noopener noreferrer", target: "_blank" } : {})}
 					>
 						<Icon
-							className={`h-auto w-[5vw] min-w-[55px] transition-transform duration-300 group-hover:scale-110 ${hoverColour}`}
+							className={`size-8 transition-transform duration-300 group-hover:scale-110 ${hoverColour}`}
 						/>
 					</Link>
 				))}
 			</div>
-			<div className="justify-centre mt-5 flex md:mt-8">
-				<Link
-					className="mx-auto inline-block min-w-[280px] whitespace-nowrap rounded bg-primary px-2 py-2 text-center text-white uppercase shadow hover:scale-105 hover:shadow-lg"
-					href="/subscribe"
-					prefetch={true}
-				>
-					{t("subscribe")}
-				</Link>
-			</div>
+			<Link className="btn btn-primary btn-wide uppercase" href="/subscribe" prefetch={true}>
+				{t("subscribe")}
+			</Link>
 		</section>
 	);
 }

--- a/src/app/[locale]/(home)/components/Sponsors.tsx
+++ b/src/app/[locale]/(home)/components/Sponsors.tsx
@@ -21,23 +21,25 @@ export default function Sponsors() {
 	const t = useTranslations("HomePage.Sponsors");
 
 	return (
-		<section className="w-full px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl md:text-4xl">{t("title")}</h2>
+		<section className="w-full bg-base-100 px-4 py-8">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="flex w-full flex-wrap justify-center gap-[15vw]">
 					{sponsors.map(({ name, href, image }) => (
 						<Link
-							className="group w-[10%] min-w-[60px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+							className="card group w-[10%] min-w-[60px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 							href={href}
 							key={name}
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<Image
-								alt={name}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
-								src={image}
-							/>
+							<figure>
+								<Image
+									alt={name}
+									className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
 						</Link>
 					))}
 				</div>

--- a/src/app/[locale]/(home)/components/UpcomingCareerEvents.tsx
+++ b/src/app/[locale]/(home)/components/UpcomingCareerEvents.tsx
@@ -8,16 +8,19 @@ import MyNaviEvent from "../images/events/MyNavi_Event.jpg";
 const events = [
 	{
 		href: "https://docs.google.com/forms/d/e/1FAIpQLSfC_Zc8xWA-dJJYbjJJUL5sr-LtRgrAgrmsCc6A2UAVw-obng/viewform",
+		id: "hnh",
 		image: HAndHEvent,
 		translationKey: "careersNetworkingEvent",
 	},
 	{
 		href: "https://regu-20105603.hs-sites.com/kpmg-aus25",
+		id: "kpmg",
 		image: KPMGEvent,
 		translationKey: "careersNetworkingEvent",
 	},
 	{
 		href: "https://global.mynavi.jp/conts/event/aus_mcs2025jul/?utm_source=studentpartnar&utm_medium=textl&utm_campaign=2507",
+		id: "mynavi",
 		image: MyNaviEvent,
 		translationKey: "careersNetworkingEvent",
 	},
@@ -27,25 +30,25 @@ export default function UpcomingCareerEvents() {
 	const t = useTranslations("HomePage.UpcomingCareerEvents");
 
 	return (
-		<section className="w-full bg-primary px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl text-white md:text-4xl">
-					{t("title")}
-				</h2>
+		<section className="w-full bg-primary px-4 py-8 text-primary-content">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="mb-[2%] flex w-full flex-wrap justify-center gap-[4vw]">
-					{events.map(({ translationKey, href, image }) => (
+					{events.map(({ id, translationKey, href, image }) => (
 						<Link
-							className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+							className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 							href={href}
-							key={translationKey}
+							key={id}
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<Image
-								alt={t(`events.${translationKey}`)}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
-								src={image}
-							/>
+							<figure>
+								<Image
+									alt={t(`events.${translationKey}`)}
+									className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
 						</Link>
 					))}
 				</div>

--- a/src/app/[locale]/(home)/components/UpcomingSocialEvents.tsx
+++ b/src/app/[locale]/(home)/components/UpcomingSocialEvents.tsx
@@ -15,15 +15,15 @@ export default function UpcomingSocialEvents() {
 	const t = useTranslations("HomePage.UpcomingSocialEvents");
 
 	return (
-		<section className="w-full px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl md:text-4xl">{t("title")}</h2>
+		<section className="w-full bg-base-100 px-4 py-8">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="flex w-full flex-wrap justify-center gap-[4vw]">
 					{events.map(({ translationKey, href, image }) => {
 						const EventImage = (
 							<Image
 								alt={t(`events.${translationKey}`)}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
+								className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
 								key={translationKey}
 								src={image}
 							/>
@@ -31,20 +31,20 @@ export default function UpcomingSocialEvents() {
 
 						return href !== undefined ? (
 							<Link
-								className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+								className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 								href={href}
 								key={translationKey}
 								rel="noopener noreferrer"
 								target="_blank"
 							>
-								{EventImage}
+								<figure>{EventImage}</figure>
 							</Link>
 						) : (
 							<div
-								className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+								className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 								key={translationKey}
 							>
-								{EventImage}
+								<figure>{EventImage}</figure>
 							</div>
 						);
 					})}

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -6,9 +6,7 @@ import AboutUs from "./components/AboutUs";
 import PastEvents from "./components/PastEvents";
 import SocialIcons from "./components/SocialIcons";
 import Sponsors from "./components/Sponsors";
-// import UpcomingCareerEvents from "./components/UpcomingCareerEvents";
 import UpcomingSocialEvents from "./components/UpcomingSocialEvents";
-// import Featured from "./components/Featured";
 import ajcLogo from "./images/large-logo.png";
 
 export default function HomePage({ params }: { params: Promise<{ locale: string }> }) {
@@ -18,29 +16,29 @@ export default function HomePage({ params }: { params: Promise<{ locale: string 
 	setRequestLocale(locale);
 	const t = useTranslations("HomePage");
 
-	// const switchTargetLocale = locale === "en" ? "ja" : "en";
-
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-items-center pb-15">
-			<Image alt="AJC Society logo" className="h-auto w-2/5" priority={true} src={ajcLogo} />
-			{/* <Link
-				className="mb-4 rounded bg-ajc-red px-4 py-2 text-2xl text-white"
-				href="/"
-				locale={switchTargetLocale}
-			>
-				{t("switchLocale", {
-					locale: switchTargetLocale === "en" ? "英語" : "Japanese",
-				})}
-			</Link> */}
-			<SocialIcons />
+		<main className="min-h-screen bg-base-100 pb-15 text-base-content">
+			<section className="hero px-4 py-8">
+				<div className="hero-content flex-col">
+					<Image
+						alt="AJC Society logo"
+						className="h-auto w-2/5 min-w-[220px] max-w-lg"
+						priority={true}
+						src={ajcLogo}
+					/>
+					<SocialIcons />
+				</div>
+			</section>
 			<AboutUs />
-			{/* <UpcomingCareerEvents /> */}
-			{/* <Featured /> */}
 			<UpcomingSocialEvents />
 			<PastEvents />
 			<Sponsors />
-			<h2 className="mt-8 mb-10 text-center font-bold text-4xl">{t("socialConnectPrompt")}</h2>
-			<SocialIcons />
+			<section className="hero px-4 py-8">
+				<div className="hero-content flex-col text-center">
+					<h2 className="text-4xl font-bold">{t("socialConnectPrompt")}</h2>
+					<SocialIcons />
+				</div>
+			</section>
 		</main>
 	);
 }

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -17,7 +17,7 @@ export default function HomePage({ params }: { params: Promise<{ locale: string 
 	const t = useTranslations("HomePage");
 
 	return (
-		<main className="min-h-screen bg-base-100 pb-15 text-base-content">
+		<main className="min-h-screen bg-base-100 pb-16 text-base-content">
 			<section className="hero px-4 py-8">
 				<div className="hero-content flex-col">
 					<Image

--- a/src/app/[locale]/archive/ArchiveClient.tsx
+++ b/src/app/[locale]/archive/ArchiveClient.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+import {
+	type Article,
+	type ArticleFilterCategory,
+	articleFilterCategories,
+	type NewsletterEdition,
+} from "../../../data/archive";
+
+type ArchiveSection = "newsletter" | "articles";
+
+export interface ArchiveTranslations {
+	articles: string;
+	byline: string;
+	categories: Record<ArticleFilterCategory, string>;
+	loadMore: string;
+	newsletter: string;
+	noArticles: string;
+	noNewsletters: string;
+	readOnline: string;
+}
+
+interface ArchiveClientProps {
+	articles: Article[];
+	locale: string;
+	newsletters: NewsletterEdition[];
+	translations: ArchiveTranslations;
+}
+
+function getSectionFromHash(): ArchiveSection {
+	return window.location.hash === "#articles" ? "articles" : "newsletter";
+}
+
+export default function ArchiveClient({
+	articles,
+	locale,
+	newsletters,
+	translations,
+}: ArchiveClientProps) {
+	const [activeSection, setActiveSection] = useState<ArchiveSection>("newsletter");
+	const [activeCategory, setActiveCategory] = useState<ArticleFilterCategory>("All");
+	const [visibleArticlesCount, setVisibleArticlesCount] = useState(9);
+	const [selectedNewsletter, setSelectedNewsletter] = useState<NewsletterEdition | undefined>(
+		newsletters[0],
+	);
+
+	useEffect(() => {
+		const syncSectionFromHash = () => setActiveSection(getSectionFromHash());
+
+		syncSectionFromHash();
+		window.addEventListener("hashchange", syncSectionFromHash);
+
+		return () => window.removeEventListener("hashchange", syncSectionFromHash);
+	}, []);
+
+	const handleSectionChange = (section: ArchiveSection) => {
+		setActiveSection(section);
+		window.history.replaceState(null, "", `#${section}`);
+	};
+
+	const filteredArticles = useMemo(
+		() =>
+			activeCategory === "All"
+				? articles
+				: articles.filter((article) => article.categories.includes(activeCategory)),
+		[activeCategory, articles],
+	);
+	const visibleArticles = filteredArticles.slice(0, visibleArticlesCount);
+	const authorListFormatter = useMemo(
+		() => new Intl.ListFormat(locale, { style: "long", type: "conjunction" }),
+		[locale],
+	);
+
+	return (
+		<div className="flex w-full flex-col items-center">
+			<div className="join mb-10 rounded-full bg-base-200 p-1">
+				<button
+					aria-pressed={activeSection === "newsletter"}
+					className={`btn join-item rounded-full ${
+						activeSection === "newsletter" ? "btn-primary" : "btn-ghost"
+					}`}
+					onClick={() => handleSectionChange("newsletter")}
+					type="button"
+				>
+					{translations.newsletter}
+				</button>
+				<button
+					aria-pressed={activeSection === "articles"}
+					className={`btn join-item rounded-full ${
+						activeSection === "articles" ? "btn-primary" : "btn-ghost"
+					}`}
+					onClick={() => handleSectionChange("articles")}
+					type="button"
+				>
+					{translations.articles}
+				</button>
+			</div>
+
+			{activeSection === "newsletter" && (
+				<section className="w-full">
+					{newsletters.length === 0 ? (
+						<div className="alert mx-auto max-w-3xl bg-base-200">
+							<span>{translations.noNewsletters}</span>
+						</div>
+					) : (
+						<div className="mx-auto flex w-full max-w-6xl flex-col-reverse gap-8 lg:flex-row lg:gap-12">
+							<div className="flex flex-1 flex-col gap-4">
+								{newsletters.map((edition) => (
+									<button
+										aria-pressed={selectedNewsletter?.id === edition.id}
+										className={`card w-full border border-base-200 bg-base-100 text-left shadow-sm transition-colors hover:bg-base-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+											selectedNewsletter?.id === edition.id ? "ring-2 ring-primary" : ""
+										}`}
+										key={edition.id}
+										onClick={() => setSelectedNewsletter(edition)}
+										type="button"
+									>
+										<span className="card-body p-6">
+											<time className="text-sm opacity-70" dateTime={edition.dateISO}>
+												{edition.dateLabel}
+											</time>
+											<span className="card-title text-xl">{edition.title}</span>
+										</span>
+									</button>
+								))}
+							</div>
+
+							{selectedNewsletter && (
+								<div className="self-start lg:sticky lg:top-24 lg:flex-[1.5]">
+									<div className="mockup-browser overflow-hidden rounded-box border border-base-300 bg-base-300 shadow-2xl">
+										<div className="mockup-browser-toolbar">
+											<div className="input truncate border border-base-300 text-sm">
+												{selectedNewsletter.url}
+											</div>
+										</div>
+										<div className="relative flex h-[500px] w-full justify-center bg-base-200 lg:h-[700px]">
+											<iframe
+												className="h-full w-full bg-white"
+												loading="lazy"
+												referrerPolicy="no-referrer"
+												sandbox="allow-scripts"
+												src={selectedNewsletter.url}
+												title={selectedNewsletter.title}
+											/>
+										</div>
+									</div>
+									<a
+										className="btn btn-primary mt-4 w-full"
+										href={selectedNewsletter.url}
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										{translations.readOnline}
+									</a>
+								</div>
+							)}
+						</div>
+					)}
+				</section>
+			)}
+
+			{activeSection === "articles" && (
+				<section className="flex w-full flex-col items-center">
+					<div className="mb-6 flex w-full justify-start overflow-x-auto pb-4 lg:justify-center">
+						<div className="flex gap-2 px-2">
+							{articleFilterCategories.map((category) => (
+								<button
+									className={`btn btn-sm rounded-full ${
+										activeCategory === category ? "btn-primary" : "btn-outline"
+									}`}
+									key={category}
+									onClick={() => {
+										setActiveCategory(category);
+										setVisibleArticlesCount(9);
+									}}
+									type="button"
+								>
+									{translations.categories[category]}
+								</button>
+							))}
+						</div>
+					</div>
+
+					{visibleArticles.length === 0 ? (
+						<div className="alert mx-auto max-w-3xl bg-base-200">
+							<span>{translations.noArticles}</span>
+						</div>
+					) : (
+						<div className="mx-auto grid w-full max-w-6xl grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+							{visibleArticles.map((article) => (
+								<a
+									className="card group overflow-hidden border border-base-200 bg-base-100 shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+									href={article.url}
+									key={article.id}
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									<figure className="relative aspect-[3/2] bg-base-200">
+										<Image
+											alt={article.title}
+											className="object-cover transition-transform duration-500 group-hover:scale-105"
+											fill={true}
+											sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+											src={article.coverImage}
+										/>
+									</figure>
+									<div className="card-body p-6">
+										<div className="mb-2 flex flex-wrap gap-2">
+											{article.categories.map((category) => (
+												<span className="badge badge-primary badge-outline" key={category}>
+													{translations.categories[category]}
+												</span>
+											))}
+										</div>
+										<h3 className="card-title line-clamp-2 text-xl">{article.title}</h3>
+										<p className="line-clamp-1 text-sm opacity-70">
+											{translations.byline.replace(
+												"{authors}",
+												authorListFormatter.format(article.authors),
+											)}
+										</p>
+										<div className="mt-auto text-sm opacity-60">
+											<time dateTime={article.dateISO}>{article.dateLabel}</time>
+										</div>
+									</div>
+								</a>
+							))}
+						</div>
+					)}
+
+					{visibleArticles.length < filteredArticles.length && (
+						<div className="mt-12 text-center">
+							<button
+								className="btn btn-outline"
+								onClick={() => setVisibleArticlesCount((count) => count + 9)}
+								type="button"
+							>
+								{translations.loadMore}
+							</button>
+						</div>
+					)}
+				</section>
+			)}
+		</div>
+	);
+}

--- a/src/app/[locale]/archive/page.tsx
+++ b/src/app/[locale]/archive/page.tsx
@@ -1,0 +1,53 @@
+import { type Locale, useTranslations } from "next-intl";
+import { setRequestLocale } from "next-intl/server";
+import { use } from "react";
+import ArchiveClient from "./ArchiveClient";
+import { articles, newsletters } from "../../../data/archive";
+
+export default function ArchivePage({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale: routeLocale } = use(params);
+	const locale = routeLocale as Locale;
+	// Enable static rendering
+	setRequestLocale(locale);
+
+	const t = useTranslations("ArchivePage");
+
+	const translations = {
+		title: t("title"),
+		subtitle: t("subtitle"),
+		newsletter: t("newsletter"),
+		articles: t("articles"),
+		readOnline: t("readOnline"),
+		byline: t("byline", { authors: "{authors}" }),
+		categories: {
+			All: t("categories.All"),
+			Business: t("categories.Business"),
+			Culture: t("categories.Culture"),
+			Careers: t("categories.Careers"),
+			Events: t("categories.Events"),
+		},
+		loadMore: t("loadMore"),
+		noArticles: t("noArticles"),
+		noNewsletters: t("noNewsletters"),
+	};
+
+	return (
+		<main className="flex min-h-screen w-full flex-col bg-base-100 pb-20">
+			<section className="hero bg-primary px-4 py-16 text-center text-primary-content">
+				<div className="hero-content flex-col">
+					<h1 className="text-4xl font-bold md:text-5xl">{translations.title}</h1>
+					<p className="max-w-2xl text-lg opacity-90 md:text-xl">{translations.subtitle}</p>
+				</div>
+			</section>
+
+			<div className="mx-auto mt-8 w-full max-w-7xl flex-1 px-4 lg:px-8">
+				<ArchiveClient
+					articles={articles}
+					locale={locale}
+					newsletters={newsletters}
+					translations={translations}
+				/>
+			</div>
+		</main>
+	);
+}

--- a/src/app/[locale]/components/Navbar.tsx
+++ b/src/app/[locale]/components/Navbar.tsx
@@ -1,0 +1,38 @@
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+import { Link } from "../../../i18n/navigation";
+import ajcLogo from "../(home)/images/large-logo.png";
+
+export default function Navbar() {
+	const t = useTranslations("Navigation");
+
+	return (
+		<nav className="navbar sticky top-0 z-50 bg-base-100 px-4 text-base-content shadow-sm lg:px-8">
+			<div className="flex-1">
+				<Link className="btn btn-ghost h-auto py-2 text-xl normal-case" href="/">
+					<Image alt="AJC Logo" className="h-auto w-24 md:w-32" priority={true} src={ajcLogo} />
+				</Link>
+			</div>
+			<div className="flex-none">
+				<ul className="menu menu-horizontal items-center gap-2 px-1">
+					<li>
+						<Link href="/">{t("home")}</Link>
+					</li>
+					<li>
+						<details className="dropdown dropdown-end">
+							<summary className="cursor-pointer">{t("archive")}</summary>
+							<ul className="menu dropdown-content z-50 mt-4 min-w-40 rounded-box bg-base-100 p-2 shadow">
+								<li>
+									<Link href="/archive#newsletter">{t("newsletter")}</Link>
+								</li>
+								<li>
+									<Link href="/archive#articles">{t("articles")}</Link>
+								</li>
+							</ul>
+						</details>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	);
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { hasLocale, type Locale, NextIntlClientProvider } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { ReactNode } from "react";
 import { routing } from "../../i18n/routing";
+import Navbar from "./components/Navbar";
 
 export async function generateMetadata({
 	params,
@@ -62,7 +63,10 @@ export default async function RootLayout({
 	return (
 		<html lang={locale}>
 			<body className="h-full w-full bg-base-100 font-sans text-base-content">
-				<NextIntlClientProvider>{children}</NextIntlClientProvider>
+				<NextIntlClientProvider>
+					<Navbar />
+					{children}
+				</NextIntlClientProvider>
 			</body>
 		</html>
 	);

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
 
 	return (
 		<html lang={locale}>
-			<body className="h-full w-full bg-background font-sans text-text">
+			<body className="h-full w-full bg-base-100 font-sans text-base-content">
 				<NextIntlClientProvider>{children}</NextIntlClientProvider>
 			</body>
 		</html>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,12 +3,47 @@
 	themes: false;
 }
 
+@plugin "daisyui/theme" {
+	name: "ajc";
+	default: true;
+	color-scheme: light;
+
+	--color-base-100: #f5efe7;
+	--color-base-200: #efe4d8;
+	--color-base-300: #dccfc0;
+	--color-base-content: #231f20;
+	--color-primary: #a73f3e;
+	--color-primary-content: #ffffff;
+	--color-secondary: #231f20;
+	--color-secondary-content: #f5efe7;
+	--color-accent: #d7a449;
+	--color-accent-content: #231f20;
+	--color-neutral: #231f20;
+	--color-neutral-content: #f5efe7;
+	--color-info: #2563eb;
+	--color-info-content: #ffffff;
+	--color-success: #15803d;
+	--color-success-content: #ffffff;
+	--color-warning: #b45309;
+	--color-warning-content: #ffffff;
+	--color-error: #b91c1c;
+	--color-error-content: #ffffff;
+
+	--radius-selector: 0.5rem;
+	--radius-field: 0.375rem;
+	--radius-box: 0.75rem;
+	--size-selector: 0.25rem;
+	--size-field: 0.25rem;
+	--border: 1px;
+	--depth: 1;
+	--noise: 0;
+}
+
 @theme {
 	--color-ajc-beige: #f5efe7;
 	--color-ajc-red: #a73f3e;
 	--color-ajc-black: #231f20;
 
-	--color-background: var(--color-ajc-beige);
-	--color-text: var(--color-ajc-black);
-	--color-primary: var(--color-ajc-red);
+	--color-background: var(--color-base-100);
+	--color-text: var(--color-base-content);
 }

--- a/src/data/archive.ts
+++ b/src/data/archive.ts
@@ -1,0 +1,28 @@
+export const articleCategories = ["Business", "Culture", "Careers", "Events"] as const;
+export type ArticleCategory = (typeof articleCategories)[number];
+
+export const articleFilterCategories = ["All", ...articleCategories] as const;
+export type ArticleFilterCategory = (typeof articleFilterCategories)[number];
+
+export interface Article {
+	id: string;
+	title: string;
+	dateISO: string;
+	dateLabel: string;
+	authors: string[];
+	categories: ArticleCategory[];
+	coverImage: string;
+	url: string;
+}
+
+export interface NewsletterEdition {
+	id: string;
+	title: string;
+	dateISO: string;
+	dateLabel: string;
+	url: string;
+}
+
+export const articles: Article[] = [];
+
+export const newsletters: NewsletterEdition[] = [];


### PR DESCRIPTION
## Summary
- Stacked this PR on #442 (`chore/full-daisyui-migration`) by rebasing `feat/archive-page`.
- Adds the localized archive route, global navbar, and typed archive client UI using daisyUI primitives.
- Removes fake `example.com` article content and MailerLite preview URLs that redirected to login; the archive now ships with proper empty states until real public content is available.
- Applies the prior Copilot review feedback: distinct archive anchors, typed translations, accessible newsletter selection, sandboxed iframe previews, responsive image sizes, and route-param consistency.

## Checks
- npm run format
- npm run lint
- npm run build