### PR TITLE
refactor: migrate components to daisyUI

### DIFF
--- a/src/app/[locale]/(home)/@modal/(.)subscribe/SubscribeModal.tsx
+++ b/src/app/[locale]/(home)/@modal/(.)subscribe/SubscribeModal.tsx
@@ -18,7 +18,7 @@ export default function SubscribeModal() {
 
 	return (
 		<dialog className="modal" onClose={onClose} open={true}>
-			<div className="modal-box rounded-lg bg-ajc-beige p-6">
+			<div className="modal-box bg-base-100 p-6">
 				<form method="dialog">
 					<button
 						className="btn btn-sm btn-circle btn-ghost absolute top-2 right-2"
@@ -30,30 +30,42 @@ export default function SubscribeModal() {
 				</form>
 				{state?.success ? (
 					<div className="flex flex-col items-center justify-center py-8">
-						<h2 className="mb-6 font-bold text-2xl">{t("completed.title")}</h2>
+						<h2 className="mb-6 text-2xl font-bold">{t("completed.title")}</h2>
 						<p className="mb-6 text-center">{t("completed.message")}</p>
 					</div>
 				) : (
 					<>
-						<h2 className="font-bold text-2xl">{t("title")}</h2>
+						<h2 className="text-2xl font-bold">{t("title")}</h2>
 						<p className="py-4">{t("description")}</p>
-						<form action={action} className="flex flex-col space-y-4">
+						<form action={action} className="space-y-4">
 							<input
-								className="input input-bordered w-full"
+								className="input input-primary w-full"
 								name="name"
 								placeholder={t("namePlaceholder")}
 								required={true}
 								type="text"
 							/>
 							<input
-								className="input input-bordered w-full"
+								className="input input-primary w-full"
 								name="email"
 								placeholder={t("emailPlaceholder")}
 								required={true}
 								type="email"
 							/>
-							<button className="btn btn-primary text-white" disabled={isPending} type="submit">
-								{isPending ? t("buttonTextPending") : t("buttonText")}
+							<button
+								aria-busy={isPending}
+								className="btn btn-primary w-full"
+								disabled={isPending}
+								type="submit"
+							>
+								{isPending ? (
+									<>
+										<span className="loading loading-spinner" />
+										{t("buttonTextPending")}
+									</>
+								) : (
+									t("buttonText")
+								)}
 							</button>
 						</form>
 					</>

--- a/src/app/[locale]/(home)/components/AboutUs.tsx
+++ b/src/app/[locale]/(home)/components/AboutUs.tsx
@@ -7,26 +7,26 @@ export default function AboutUs() {
 	const t = useTranslations("HomePage.AboutUs");
 
 	return (
-		<section>
-			<div className="flex flex-col items-center px-6 py-10 md:flex-row md:px-10">
-				<div className="mb-6 flex justify-center px-10 md:w-1/2">
+		<section className="hero bg-base-100 py-10">
+			<div className="hero-content flex-col gap-8 px-6 md:flex-row md:px-10">
+				<figure className="flex justify-center md:w-1/2">
 					<Image
 						alt="Picture of Our 2025 Team"
-						className="h-full w-full rounded-xl object-cover shadow-lg"
+						className="h-full w-full rounded-box object-cover shadow-lg"
 						src={teamPicture}
 					/>
-				</div>
+				</figure>
 
 				<div className="max-w-xl px-4 text-center md:w-1/2 md:pl-12 md:text-left">
-					<h2 className="mb-4 font-bold text-3xl capitalize">{t("title")}</h2>
-					<p className="mb-5 text-md leading-relaxed">
+					<h2 className="mb-4 text-3xl font-bold capitalize">{t("title")}</h2>
+					<p className="mb-5 leading-relaxed">
 						{t.rich("description", {
 							br: () => <br />,
 						})}
 					</p>
-					<div className="mt-4 flex">
+					<div className="mt-4 flex justify-center md:justify-start">
 						<Link
-							className="mx-auto inline-block min-w-[250px] whitespace-nowrap rounded bg-primary px-2 py-2 text-center text-white uppercase shadow hover:scale-110 hover:shadow-lg"
+							className="btn btn-primary btn-wide uppercase"
 							href="https://campus.hellorubric.com/?tab=memberships&s=12445"
 							rel="noopener noreferrer"
 							target="_blank"

--- a/src/app/[locale]/(home)/components/Featured.tsx
+++ b/src/app/[locale]/(home)/components/Featured.tsx
@@ -4,49 +4,49 @@ import { Link } from "../../../../i18n/navigation";
 import subcomRecruitment from "../images/subcom-recruitment.png";
 import welcomeEvent from "../images/welcome-event.png";
 
+const features = [
+	{
+		altKey: "subcomAlt",
+		href: "https://forms.gle/tsGYkz3nnXCzL9UcA",
+		image: subcomRecruitment,
+		titleKey: "subcomTitle",
+	},
+	{
+		altKey: "welcomeAlt",
+		href: "https://forms.gle/eP9ruxk9DGujmdWE8",
+		image: welcomeEvent,
+		titleKey: "welcomeTitle",
+	},
+] as const;
+
 export default function Featured() {
 	const t = useTranslations("HomePage.Featured");
 
 	return (
-		<section className="w-full px-4 py-8">
+		<section className="w-full bg-base-100 px-4 py-8">
 			<div className="mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl md:text-4xl">{t("title")}</h2>
-				<div className="flex w-full flex-col items-center gap-8 md:flex-row md:justify-center md:items-start">
-					<div className="flex flex-col items-center gap-4 w-full md:w-1/4 group">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
+				<div className="grid w-full max-w-4xl grid-cols-1 gap-8 md:grid-cols-2">
+					{features.map(({ altKey, href, image, titleKey }) => (
 						<Link
-							href="https://forms.gle/tsGYkz3nnXCzL9UcA"
+							className="card group bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
+							href={href}
+							key={href}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex flex-col items-center gap-4 w-full transition-transform hover:scale-105"
 						>
-							<Image
-								src={subcomRecruitment}
-								alt={t("subcomAlt")}
-								className="h-auto w-full rounded-lg shadow-lg"
-							/>
-							<span className="rounded-full bg-ajc-red px-6 py-2 text-white font-bold shadow-md transition-colors hover:bg-red-700">
-								{t("subcomTitle")}
-							</span>
+							<figure>
+								<Image
+									alt={t(altKey)}
+									className="h-auto w-full transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
+							<div className="card-body items-center p-4">
+								<span className="btn btn-primary btn-wide">{t(titleKey)}</span>
+							</div>
 						</Link>
-					</div>
-
-					<div className="flex flex-col items-center gap-4 w-full md:w-1/4 group">
-						<Link
-							href="https://forms.gle/eP9ruxk9DGujmdWE8"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="flex flex-col items-center gap-4 w-full transition-transform hover:scale-105"
-						>
-							<Image
-								src={welcomeEvent}
-								alt={t("welcomeAlt")}
-								className="h-auto w-full rounded-lg shadow-lg"
-							/>
-							<span className="rounded-full bg-ajc-red px-6 py-2 text-white font-bold shadow-md transition-colors hover:bg-red-700">
-								{t("welcomeTitle")}
-							</span>
-						</Link>
-					</div>
+					))}
 				</div>
 			</div>
 		</section>

--- a/src/app/[locale]/(home)/components/PastEvents.tsx
+++ b/src/app/[locale]/(home)/components/PastEvents.tsx
@@ -8,16 +8,19 @@ import MyNaviEvent from "../images/events/MyNavi_Event.jpg";
 const pastEvents = [
 	{
 		href: "https://docs.google.com/forms/d/e/1FAIpQLSfC_Zc8xWA-dJJYbjJJUL5sr-LtRgrAgrmsCc6A2UAVw-obng/viewform",
+		id: "hnh",
 		image: HAndHEvent,
 		translationKey: "networking",
 	},
 	{
 		href: "https://regu-20105603.hs-sites.com/kpmg-aus25",
+		id: "kpmg",
 		image: KPMGEvent,
 		translationKey: "networking",
 	},
 	{
 		href: "https://global.mynavi.jp/conts/event/aus_mcs2025jul/?utm_source=studentpartnar&utm_medium=textl&utm_campaign=2507",
+		id: "mynavi",
 		image: MyNaviEvent,
 		translationKey: "networking",
 	},
@@ -27,25 +30,25 @@ export default function PastEvents() {
 	const t = useTranslations("HomePage.PastEvents");
 
 	return (
-		<section className="w-full bg-ajc-beige-500 px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl text-ajc-text md:text-4xl">
-					{t("title")}
-				</h2>
+		<section className="w-full bg-base-200 px-4 py-8">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="flex w-full flex-wrap justify-center gap-[4vw]">
-					{pastEvents.map(({ translationKey, href, image }) => (
+					{pastEvents.map(({ id, translationKey, href, image }) => (
 						<Link
-							className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+							className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 							href={href}
-							key={translationKey}
+							key={id}
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<Image
-								alt={t(`events.${translationKey}`)}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
-								src={image}
-							/>
+							<figure>
+								<Image
+									alt={t(`events.${translationKey}`)}
+									className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
 						</Link>
 					))}
 				</div>

--- a/src/app/[locale]/(home)/components/SocialIcons.tsx
+++ b/src/app/[locale]/(home)/components/SocialIcons.tsx
@@ -7,25 +7,25 @@ const socials = [
 		hoverColour: "group-hover:fill-pink-500",
 		href: "https://www.instagram.com/ajcsocunsw/",
 		icon: FaInstagram,
-		key: "instagram",
+		label: "Instagram",
 	},
 	{
 		hoverColour: "group-hover:fill-blue-500",
 		href: "https://www.facebook.com/people/UNSW-Australia-Japan-Career-Development-Society-AJC/100095045665332/",
 		icon: FaFacebook,
-		key: "facebook",
+		label: "Facebook",
 	},
 	{
 		hoverColour: "group-hover:fill-blue-700",
 		href: "https://www.linkedin.com/company/unsw-australia-japan-career-development-society",
 		icon: FaLinkedin,
-		key: "linkedin",
+		label: "LinkedIn",
 	},
 	{
 		hoverColour: "group-hover:fill-blue-700",
 		href: "https://discord.gg/a3KJ49CwaZ",
 		icon: FaDiscord,
-		key: "discord",
+		label: "Discord",
 	},
 ] as const;
 
@@ -33,30 +33,26 @@ export default function SocialIcons() {
 	const t = useTranslations("HomePage.Social");
 
 	return (
-		<section>
-			<div className="flex items-center gap-x-[5vw]">
-				{socials.map(({ href, icon: Icon, hoverColour, key }) => (
+		<section className="flex flex-col items-center gap-5 md:gap-8">
+			<div className="flex flex-wrap items-center justify-center gap-3 md:gap-5">
+				{socials.map(({ href, icon: Icon, hoverColour, label }) => (
 					<Link
-						className="group"
+						aria-label={label}
+						className="tooltip btn btn-ghost btn-circle group h-14 w-14 min-h-14 text-base-content hover:bg-base-200"
+						data-tip={label}
 						href={href}
-						key={key}
+						key={label}
 						{...(href.startsWith("http") ? { rel: "noopener noreferrer", target: "_blank" } : {})}
 					>
 						<Icon
-							className={`h-auto w-[5vw] min-w-[55px] transition-transform duration-300 group-hover:scale-110 ${hoverColour}`}
+							className={`size-8 transition-transform duration-300 group-hover:scale-110 ${hoverColour}`}
 						/>
 					</Link>
 				))}
 			</div>
-			<div className="justify-centre mt-5 flex md:mt-8">
-				<Link
-					className="mx-auto inline-block min-w-[280px] whitespace-nowrap rounded bg-primary px-2 py-2 text-center text-white uppercase shadow hover:scale-105 hover:shadow-lg"
-					href="/subscribe"
-					prefetch={true}
-				>
-					{t("subscribe")}
-				</Link>
-			</div>
+			<Link className="btn btn-primary btn-wide uppercase" href="/subscribe" prefetch={true}>
+				{t("subscribe")}
+			</Link>
 		</section>
 	);
 }

--- a/src/app/[locale]/(home)/components/Sponsors.tsx
+++ b/src/app/[locale]/(home)/components/Sponsors.tsx
@@ -21,23 +21,25 @@ export default function Sponsors() {
 	const t = useTranslations("HomePage.Sponsors");
 
 	return (
-		<section className="w-full px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl md:text-4xl">{t("title")}</h2>
+		<section className="w-full bg-base-100 px-4 py-8">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="flex w-full flex-wrap justify-center gap-[15vw]">
 					{sponsors.map(({ name, href, image }) => (
 						<Link
-							className="group w-[10%] min-w-[60px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+							className="card group w-[10%] min-w-[60px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 							href={href}
 							key={name}
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<Image
-								alt={name}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
-								src={image}
-							/>
+							<figure>
+								<Image
+									alt={name}
+									className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
 						</Link>
 					))}
 				</div>

--- a/src/app/[locale]/(home)/components/UpcomingCareerEvents.tsx
+++ b/src/app/[locale]/(home)/components/UpcomingCareerEvents.tsx
@@ -8,16 +8,19 @@ import MyNaviEvent from "../images/events/MyNavi_Event.jpg";
 const events = [
 	{
 		href: "https://docs.google.com/forms/d/e/1FAIpQLSfC_Zc8xWA-dJJYbjJJUL5sr-LtRgrAgrmsCc6A2UAVw-obng/viewform",
+		id: "hnh",
 		image: HAndHEvent,
 		translationKey: "careersNetworkingEvent",
 	},
 	{
 		href: "https://regu-20105603.hs-sites.com/kpmg-aus25",
+		id: "kpmg",
 		image: KPMGEvent,
 		translationKey: "careersNetworkingEvent",
 	},
 	{
 		href: "https://global.mynavi.jp/conts/event/aus_mcs2025jul/?utm_source=studentpartnar&utm_medium=textl&utm_campaign=2507",
+		id: "mynavi",
 		image: MyNaviEvent,
 		translationKey: "careersNetworkingEvent",
 	},
@@ -27,25 +30,25 @@ export default function UpcomingCareerEvents() {
 	const t = useTranslations("HomePage.UpcomingCareerEvents");
 
 	return (
-		<section className="w-full bg-primary px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl text-white md:text-4xl">
-					{t("title")}
-				</h2>
+		<section className="w-full bg-primary px-4 py-8 text-primary-content">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="mb-[2%] flex w-full flex-wrap justify-center gap-[4vw]">
-					{events.map(({ translationKey, href, image }) => (
+					{events.map(({ id, translationKey, href, image }) => (
 						<Link
-							className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+							className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 							href={href}
-							key={translationKey}
+							key={id}
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<Image
-								alt={t(`events.${translationKey}`)}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
-								src={image}
-							/>
+							<figure>
+								<Image
+									alt={t(`events.${translationKey}`)}
+									className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
+									src={image}
+								/>
+							</figure>
 						</Link>
 					))}
 				</div>

--- a/src/app/[locale]/(home)/components/UpcomingSocialEvents.tsx
+++ b/src/app/[locale]/(home)/components/UpcomingSocialEvents.tsx
@@ -15,15 +15,15 @@ export default function UpcomingSocialEvents() {
 	const t = useTranslations("HomePage.UpcomingSocialEvents");
 
 	return (
-		<section className="w-full px-4 py-8">
-			<div className=" mx-auto flex w-full flex-col items-center">
-				<h2 className="mb-10 text-center font-bold text-2xl md:text-4xl">{t("title")}</h2>
+		<section className="w-full bg-base-100 px-4 py-8">
+			<div className="mx-auto flex w-full flex-col items-center">
+				<h2 className="mb-10 text-center text-2xl font-bold md:text-4xl">{t("title")}</h2>
 				<div className="flex w-full flex-wrap justify-center gap-[4vw]">
 					{events.map(({ translationKey, href, image }) => {
 						const EventImage = (
 							<Image
 								alt={t(`events.${translationKey}`)}
-								className="h-full w-full rounded-xl object-contain shadow transition-transform duration-300 hover:shadow-lg group-hover:scale-110"
+								className="h-full w-full object-contain transition-transform duration-300 group-hover:scale-105"
 								key={translationKey}
 								src={image}
 							/>
@@ -31,20 +31,20 @@ export default function UpcomingSocialEvents() {
 
 						return href !== undefined ? (
 							<Link
-								className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+								className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 								href={href}
 								key={translationKey}
 								rel="noopener noreferrer"
 								target="_blank"
 							>
-								{EventImage}
+								<figure>{EventImage}</figure>
 							</Link>
 						) : (
 							<div
-								className="group w-[26%] min-w-[140px] flex-wrap rounded-xl bg-white shadow transition duration-300 hover:shadow-lg"
+								className="card group w-[26%] min-w-[140px] overflow-hidden bg-base-100 shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl"
 								key={translationKey}
 							>
-								{EventImage}
+								<figure>{EventImage}</figure>
 							</div>
 						);
 					})}

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -6,9 +6,7 @@ import AboutUs from "./components/AboutUs";
 import PastEvents from "./components/PastEvents";
 import SocialIcons from "./components/SocialIcons";
 import Sponsors from "./components/Sponsors";
-// import UpcomingCareerEvents from "./components/UpcomingCareerEvents";
 import UpcomingSocialEvents from "./components/UpcomingSocialEvents";
-// import Featured from "./components/Featured";
 import ajcLogo from "./images/large-logo.png";
 
 export default function HomePage({ params }: { params: Promise<{ locale: string }> }) {
@@ -18,29 +16,29 @@ export default function HomePage({ params }: { params: Promise<{ locale: string 
 	setRequestLocale(locale);
 	const t = useTranslations("HomePage");
 
-	// const switchTargetLocale = locale === "en" ? "ja" : "en";
-
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-items-center pb-15">
-			<Image alt="AJC Society logo" className="h-auto w-2/5" priority={true} src={ajcLogo} />
-			{/* <Link
-				className="mb-4 rounded bg-ajc-red px-4 py-2 text-2xl text-white"
-				href="/"
-				locale={switchTargetLocale}
-			>
-				{t("switchLocale", {
-					locale: switchTargetLocale === "en" ? "英語" : "Japanese",
-				})}
-			</Link> */}
-			<SocialIcons />
+		<main className="min-h-screen bg-base-100 pb-15 text-base-content">
+			<section className="hero px-4 py-8">
+				<div className="hero-content flex-col">
+					<Image
+						alt="AJC Society logo"
+						className="h-auto w-2/5 min-w-[220px] max-w-lg"
+						priority={true}
+						src={ajcLogo}
+					/>
+					<SocialIcons />
+				</div>
+			</section>
 			<AboutUs />
-			{/* <UpcomingCareerEvents /> */}
-			{/* <Featured /> */}
 			<UpcomingSocialEvents />
 			<PastEvents />
 			<Sponsors />
-			<h2 className="mt-8 mb-10 text-center font-bold text-4xl">{t("socialConnectPrompt")}</h2>
-			<SocialIcons />
+			<section className="hero px-4 py-8">
+				<div className="hero-content flex-col text-center">
+					<h2 className="text-4xl font-bold">{t("socialConnectPrompt")}</h2>
+					<SocialIcons />
+				</div>
+			</section>
 		</main>
 	);
 }

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -17,7 +17,7 @@ export default function HomePage({ params }: { params: Promise<{ locale: string 
 	const t = useTranslations("HomePage");
 
 	return (
-		<main className="min-h-screen bg-base-100 pb-15 text-base-content">
+		<main className="min-h-screen bg-base-100 pb-16 text-base-content">
 			<section className="hero px-4 py-8">
 				<div className="hero-content flex-col">
 					<Image

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
 
 	return (
 		<html lang={locale}>
-			<body className="h-full w-full bg-background font-sans text-text">
+			<body className="h-full w-full bg-base-100 font-sans text-base-content">
 				<NextIntlClientProvider>{children}</NextIntlClientProvider>
 			</body>
 		</html>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,12 +3,47 @@
 	themes: false;
 }
 
+@plugin "daisyui/theme" {
+	name: "ajc";
+	default: true;
+	color-scheme: light;
+
+	--color-base-100: #f5efe7;
+	--color-base-200: #efe4d8;
+	--color-base-300: #dccfc0;
+	--color-base-content: #231f20;
+	--color-primary: #a73f3e;
+	--color-primary-content: #ffffff;
+	--color-secondary: #231f20;
+	--color-secondary-content: #f5efe7;
+	--color-accent: #d7a449;
+	--color-accent-content: #231f20;
+	--color-neutral: #231f20;
+	--color-neutral-content: #f5efe7;
+	--color-info: #2563eb;
+	--color-info-content: #ffffff;
+	--color-success: #15803d;
+	--color-success-content: #ffffff;
+	--color-warning: #b45309;
+	--color-warning-content: #ffffff;
+	--color-error: #b91c1c;
+	--color-error-content: #ffffff;
+
+	--radius-selector: 0.5rem;
+	--radius-field: 0.375rem;
+	--radius-box: 0.75rem;
+	--size-selector: 0.25rem;
+	--size-field: 0.25rem;
+	--border: 1px;
+	--depth: 1;
+	--noise: 0;
+}
+
 @theme {
 	--color-ajc-beige: #f5efe7;
 	--color-ajc-red: #a73f3e;
 	--color-ajc-black: #231f20;
 
-	--color-background: var(--color-ajc-beige);
-	--color-text: var(--color-ajc-black);
-	--color-primary: var(--color-ajc-red);
+	--color-background: var(--color-base-100);
+	--color-text: var(--color-base-content);
 }


### PR DESCRIPTION
## Summary
- Define a full AJC daisyUI theme so component tokens are available consistently.
- Migrate existing home-page components, cards, buttons, social links, and subscribe modal to daisyUI primitives.
- Clean up stale commented home-page code and fix duplicate event keys/invalid color utilities.

## Checks
- npm run format
- npm run lint
- npm run build